### PR TITLE
Add create session on connect

### DIFF
--- a/client/state/live-chat/actions.js
+++ b/client/state/live-chat/actions.js
@@ -47,8 +47,8 @@ export const connectChat = () => ( dispatch, getState ) => {
 	debug( 'requesting' );
 	// create new session id
 	
-	sign( { user } ).then( ( { jwt } ) => {
-		startSession().then( ( { session_id } ) => {
+	startSession().then( ( { session_id } ) => {
+		sign( { user, session_id } ).then( ( { jwt } ) => {
 			connection.open( user_id, jwt ).then( () => {
 				dispatch( setChatConnected() );
 				connection.on( 'event', ( event ) => dispatch( receiveChatEvent( event ) ) );

--- a/client/state/live-chat/actions.js
+++ b/client/state/live-chat/actions.js
@@ -23,6 +23,7 @@ const request = ( ... args ) => new Promise( ( resolve, reject ) => {
 } );
 
 const sign = ( payload ) => request( { method: 'POST', path: '/jwt/sign', body: { payload: JSON.stringify( payload ) } } );
+const startSession = () => request( { method: 'POST', path:'/tinkerchat/session' } );
 
 const connection = buildConnection();
 
@@ -44,10 +45,14 @@ export const connectChat = () => ( dispatch, getState ) => {
 	dispatch( setChatConnecting() );
 	// get signed identity data for authenticating
 	debug( 'requesting' );
+	// create new session id
+	
 	sign( { user } ).then( ( { jwt } ) => {
-		connection.open( user_id, jwt ).then( () => {
-			dispatch( setChatConnected() );
-			connection.on( 'event', ( event ) => dispatch( receiveChatEvent( event ) ) );
+		startSession().then( ( { session_id } ) => {
+			connection.open( user_id, jwt ).then( () => {
+				dispatch( setChatConnected() );
+				connection.on( 'event', ( event ) => dispatch( receiveChatEvent( event ) ) );
+			} );
 		} );
 	} )
 	.catch( ( e ) => {


### PR DESCRIPTION
Add calling out to the REST API to create the new session and pass that session id to the signing payload which gets passed forward to the service connection code.

The session id will pass forward along with each message to work with the storer to persist chats
